### PR TITLE
Update p2porchAllinOneTrend.sh

### DIFF
--- a/scripts/TrendMicro/p2porchAllinOneTrend.sh
+++ b/scripts/TrendMicro/p2porchAllinOneTrend.sh
@@ -2,7 +2,7 @@
 
 # this will perform the following tasks
 # 1. Install the Orchestrator Application in docker
-
+apt-get install git -y
 git clone https://github.com/sysgain/km-docker-nodejs.git ~/km-docker-nodejs
 cd ~/km-docker-nodejs
 COMPOSE_HTTP_TIMEOUT=180 sudo docker-compose up -d


### PR DESCRIPTION
Template (https://github.com/Azure/azure-quickstart-templates/tree/master/trend-chef-splunk-security) in Azure Quickstarts is failing due to this script.